### PR TITLE
move colors to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "blessed": "^0.1.81",
     "blessed-contrib": "^4.8.19",
-    "colors": "^1.4.0",
     "docdash": "^1.2.0",
     "eslint": "^6.8.0",
     "eslint-config-standard": "^14.1.1",
@@ -45,6 +44,7 @@
     "jsdoc": "^3.6.3"
   },
   "dependencies": {
+    "colors": "^1.4.0",
     "lodash": "^4.17.15"
   }
 }


### PR DESCRIPTION
`colors` is used in https://github.com/f3rno/blessed-tab-container/blob/b75f6cf9fd07fd0a501e6488f44b7f05f9446b39/lib/tab_container/args/defaults.js#L3 but not listed in the dependency